### PR TITLE
fix cropped video preview

### DIFF
--- a/CoreML-Vision-Demo/ViewController.swift
+++ b/CoreML-Vision-Demo/ViewController.swift
@@ -56,6 +56,7 @@ class ViewController: UIViewController, AVCaptureVideoDataOutputSampleBufferDele
         
         let previewLayer = AVCaptureVideoPreviewLayer(session: captureSession)
         previewLayer.frame = view.frame
+        previewLayer.videoGravity = .resizeAspectFill
         view.layer.addSublayer(previewLayer)
         
         captureSession.startRunning()


### PR DESCRIPTION
## Bug

When I tried to run this demo on the Swift Playground for iPad, the video preview is cropped.

![f90aedf2-ffae-4ceb-8887-030e37a49d1c](https://user-images.githubusercontent.com/311343/46282199-2d7dde00-c571-11e8-9348-0d31c051bd7f.png)
![ed74be1a-ade8-4bd5-8dee-c588828193f0](https://user-images.githubusercontent.com/311343/46282201-2d7dde00-c571-11e8-80dc-292bba0e6e96.png)
